### PR TITLE
copy divs for toolbox from toolbox.tmpl to PageTemplate

### DIFF
--- a/Resources/Private/Templates/DetailTemplate.html
+++ b/Resources/Private/Templates/DetailTemplate.html
@@ -43,7 +43,11 @@
 
 			<div id="c16" class="detail-view-tools">
 
-				<f:format.raw>{contentTools}</f:format.raw>
+				<div class="dropdown-menu">
+				    <input type="checkbox" id="checkbox-menu2">
+				    <label for="checkbox-menu2">Werkzeuge</label>
+					<f:format.raw>{contentTools}</f:format.raw>
+				</div>
 
 			</div>
 

--- a/Resources/Public/Css/styles.css
+++ b/Resources/Public/Css/styles.css
@@ -824,6 +824,9 @@ detail-view
     color: #fff;
     }
 
+/* Toolbox displaying */
+.detail-view-tools .dropdown-menu input[type=checkbox]:checked ~ div.tx-dlf-Toolbox  ul,
+/* TOC displaying */
 .detail-view-itemoptions .dropdown-menu input[type=checkbox]:checked ~ ul,
 .detail-view-itemoptions .dropdown-menu input[type=checkbox]:checked ~ ul ul {
     display: block;


### PR DESCRIPTION
First i tried to use toolbox.tmpl. Then i moved the html contect from `Resources/Public/PluginTemplates/toolbox.tmpl` to `Resources/Private/Templates/DetailTemplate.html`. 

Toolbox now possible to open and work out of the box.

### Incorrect html code with two select tools
When i include `toolbox.tmpl` in my typo3-element i get several blank repetitions of `headline` and `### TOOL ###` as many times as many tools from "Available Items" i select. 

#### Example:
    <div class="tx-dlf-Toolbox">
        <div class="dropdown-menu">
            <input type="checkbox" id="checkbox-menu2">
            <label for="checkbox-menu2">Werkzeuge</label>
            <ul>
                <li>
                    <div class="tx-dlf-FulltextTool">
                        <div class="dropdown-menu">
                            <input type="checkbox" id="checkbox-menu2">
                            <label for="checkbox-menu2">Werkzeuge</label>
                            <ul>
                                <!-- ###TOOLS### -->
                                <li>###TOOL###</li>
                                <!-- ###TOOLS### -->
                            </ul>
                        </div>
                    </div>
                </li>
                <li>
                    <div class="tx-dlf-ImageDownloadTool">
                        <div class="dropdown-menu">
                            <input type="checkbox" id="checkbox-menu2">
                            <label for="checkbox-menu2">Werkzeuge</label>
                            <ul>
                                <!-- ###TOOLS### -->
                                <li>###TOOL###</li>
                                <!-- ###TOOLS### -->
                            </ul>
                        </div>
                    </div>
                </li>
            </ul>
        </div>
    </div>
