### PR TITLE
Buttons in footer not visible, if you select a collection with many books (like Saxonica)

### DIFF
--- a/Resources/Public/Css/main.css
+++ b/Resources/Public/Css/main.css
@@ -58,7 +58,8 @@
 aside .tx-dlf-search {
     margin: 0;
     margin-right: 15px;
-    padding: 0px;
+    padding: 0;
+    margin-bottom: 60px;
 }
 
 li.tx-dlf-navigation-pageselect label {

--- a/Resources/Public/Css/styles.css
+++ b/Resources/Public/Css/styles.css
@@ -277,6 +277,7 @@ main aside {
 #main-content {
     float: left;
     width: 75%;
+    margin-bottom: 60px;
 }
 
 

--- a/Resources/Public/Css/styles.css
+++ b/Resources/Public/Css/styles.css
@@ -653,6 +653,8 @@ dd.tx-dlf-metadata-author,
     box-shadow: 0px 3px 0px 0px rgba(0,0,0,0.2);
     margin: 0 15px 15px 0;
     padding-bottom: 15px;
+    margin-bottom: 60px !important; /* this is not good */
+    /* reason for !importent is important in styles.css .tx-dlf-search-facets margin: 0 !important; */
 }
 
 .tx-dlf-search-facets h2 {


### PR DESCRIPTION
The buttons in the footer are not visible.
With this correction, the overlapping list is provided with final spacing