### PR TITLE
Adds class 'no-fulltext' in style.css for equal margins

### DIFF
--- a/Resources/Public/Css/styles.css
+++ b/Resources/Public/Css/styles.css
@@ -832,6 +832,7 @@ detail-view
     display: block;
 }
 
+.no-fulltext,
 .detail-view-itemoptions .dropdown-menu ul li a,
 .detail-view-itemoptions .dropdown-menu ul li .tx-dlf-toolsImagemanipulation,
 .detail-view-itemoptions .dropdown-menu ul li .tx-dlf-toolsFulltext {


### PR DESCRIPTION
Adds class 'no-fulltext', so all items in toolbox have equal margins

### Before
![image](https://user-images.githubusercontent.com/4037984/60340725-abf69780-99ac-11e9-9e8a-8523e7fe9ab7.png)


### After
![image](https://user-images.githubusercontent.com/4037984/60340668-7fdb1680-99ac-11e9-9fba-31a9ee327740.png)

