### PR TITLE
As far as i know, BackendLayout IDs / Keys should now be alphanumeric

### DIFF
--- a/Configuration/TSconfig/Page.txt
+++ b/Configuration/TSconfig/Page.txt
@@ -14,7 +14,7 @@ TCEFORM.tt_content.header_layout{
 ## Backend-Layouts definieren
 mod.web_layout.BackendLayouts {
 
-	1 {
+	DefaultTemplate {
 		title = Default Layout (Header + 2 Spalten)
 		config {
 			backend_layout {
@@ -52,7 +52,7 @@ mod.web_layout.BackendLayouts {
             }
 		}
 	}
-    2 {
+    DetailTemplate {
         title = Presentation Detail Layout
         config {
             backend_layout {
@@ -110,7 +110,7 @@ mod.web_layout.BackendLayouts {
             }
         }
     }
-    3 {
+    OneColumn {
         title = Default Layout (Header + Content)
         config {
             backend_layout {

--- a/Configuration/TypoScript/Library/2000_page.ts
+++ b/Configuration/TypoScript/Library/2000_page.ts
@@ -98,27 +98,53 @@ page.10 {
 		}
 	}
 
-	#file = {$resDir}/Resources/Private/Templates/DefaultTemplate.html
+
+    ## Template file name must be the same as the ID / Name of the backendlayout
+    ## Defined in Page.txt
+    ## ID should alphnumerical
+    templateName = TEXT
+    templateName.stdWrap {
+        cObject = TEXT
+        cObject {
+            data = levelfield:-2,backend_layout_next_level,slide
+            override.field = backend_layout
+
+            #required = 1
+
+            split {
+                token = pagets__
+                cObjNum = 1
+                1.current = 1
+            }
+        }
+
+        ifEmpty  = Default
+
+    }
+
 }
 
-page.10.file.stdWrap.cObject = CASE
-page.10.file.stdWrap.cObject {
-	key.data = pagelayout
-
-	# Default Template
-	default = TEXT
-	default.value = {$resDir}/Resources/Private/Templates/DefaultTemplate.html
-
-	pagets__1 < .default
-
-	detail = TEXT
-	detail.value = {$resDir}/Resources/Private/Templates/DetailTemplate.html
-
-	pagets__2 < .detail
-
-	onecol = TEXT
-	onecol.value = {$resDir}/Resources/Private/Templates/OneColumn.html
-
-	pagets__3 < .onecol
-
-}
+# no unnecessary repetitions
+# Directory has already been set
+# Name of the template is defined in Page.txt as Key / ID
+#page.10.file.stdWrap.cObject = CASE
+#page.10.file.stdWrap.cObject {
+#	key.data = pagelayout
+#
+#	# Default Template
+#	default = TEXT
+#	default.value = {$resDir}/Resources/Private/Templates/DefaultTemplate.html
+#
+#	pagets__1 < .default
+#
+#	detail = TEXT
+#	detail.value = {$resDir}/Resources/Private/Templates/DetailTemplate.html
+#
+#	pagets__2 < .detail
+#
+#	onecol = TEXT
+#	onecol.value = {$resDir}/Resources/Private/Templates/OneColumn.html
+#
+#	pagets__3 < .onecol
+#
+#}


### PR DESCRIPTION
Template name is formed automatically via BackendLayout ID and TemplateRootPath.
Avoids unnecessary repetitions and necessary adjustments.